### PR TITLE
Use ip's for production hosts when creating dump and syncing

### DIFF
--- a/tasks/control_host_sync.yml
+++ b/tasks/control_host_sync.yml
@@ -4,7 +4,7 @@
   command: >
     rsync {{ '--remove-source-files' if mysql_sync_delete_dump is defined else '' }} --delay-updates --compress --archive
     --out-format='{{changed_marker}}%i %n%L'
-    {{hostvars[item.source].ansible_ssh_user|default(ansible_ssh_user)}}@{{item.source}}:{{ mysql_sync_source_dump_dir }}/{{ item.database }}.sql.compressed
+    {{hostvars[item.source + '.prod'].ansible_user|default(ansible_user)}}@{{hostvars[item.source + '.prod'].ansible_host}}:{{ mysql_sync_source_dump_dir }}/{{ item.database }}.sql.compressed
     {{ mysql_sync_dump_dir }}/{{ item.database }}.sql.compressed
   delegate_to: localhost
   with_items: "{{ mysql_sync_config }}"

--- a/tasks/sql_dump.yml
+++ b/tasks/sql_dump.yml
@@ -5,7 +5,7 @@
     mysqldump {{ item.database }}
     --no-data
     > {{ mysql_sync_source_dump_dir }}/{{ item.database }}_struc.sql
-  delegate_to: "{{ item.source }}"
+  delegate_to: "{{ item.source }}.prod"
   remote_user: "{{ mysql_sync_remote_user }}"
   with_items: "{{ mysql_sync_config }}"
   check_mode: no
@@ -19,7 +19,7 @@
     {{ item.skip_tables|default('')|join(' --ignore-table ' ~ item.database ~ '.')|regex_replace('^(.)', ' --ignore-table ' ~ item.database ~ '.' ~ '\\1')}};
     } | {{ mysql_sync_compress_cmd | default(mysql_sync_default_compress_commands[mysql_sync_compress_method]['compress_cmd']) }}
     {{ mysql_sync_compress_args | default('') }} > {{ mysql_sync_source_dump_dir }}/{{ item.database }}.sql.compressed
-  delegate_to: "{{ item.source }}"
+  delegate_to: "{{ item.source }}.prod"
   remote_user: "{{ mysql_sync_remote_user }}"
   with_items: "{{ mysql_sync_config }}"
   check_mode: no

--- a/tasks/target_sync.yml
+++ b/tasks/target_sync.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Copy files from source to target.
-  shell: "rsync {{ '--remove-source-files' if mysql_sync_delete_dump is defined else '' }} --delay-updates --compress --archive --out-format='{{changed_marker}}%i %n%L' {{hostvars[item.source].ansible_ssh_user|default(ansible_ssh_user)}}@{{item.source}}:{{ mysql_sync_source_dump_dir }}/{{ item.database }}.sql.compressed {{ mysql_sync_dump_dir }}/{{ item.database }}.sql.compressed"
+  shell: "rsync {{ '--remove-source-files' if mysql_sync_delete_dump is defined else '' }} --delay-updates --compress --archive --out-format='{{changed_marker}}%i %n%L' {{hostvars[item.source + '.prod'].ansible_user|default(ansible_user)}}@{{hostvars[item.source + '.prod'].ansible_host}}:{{ mysql_sync_source_dump_dir }}/{{ item.database }}.sql.compressed {{ mysql_sync_dump_dir }}/{{ item.database }}.sql.compressed"
   check_mode: no
   with_items: "{{ mysql_sync_config }}"
 


### PR DESCRIPTION
Use production host from the inventory with a different hostname
`<hostname>.prod` when creating the dump and syncing to avoid dns/Ansible
issues where the dump would be created on the target machine instead of the
production machine. This requires that the production ip's are specified
in the inventory under the .prod hostname with `ansible_host` and possibly
the user with `ansible_user` if running against Vagrant VM where the used user
doesn't match the one used on the production machine.
This should be merged at around the same time with the corresponding file sync [change](https://github.com/libraries-fi/ansible-role-file_sync/pull/2) and possibly inventory changes.